### PR TITLE
Add release action for Linux X64 & aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: |
+          sudo apt update
+          sudo apt install gcc-aarch64-linux-gnu ninja-build
+      - uses: actions/checkout@v2
+      - name: Build for Linux X86_64
+        run: |
+          cmake -G Ninja -B build
+          ninja -C build
+          strip build/espresso
+          mv build/espresso x86_64-linux-gnu-espresso
+          rm -rf build
+      - name: Build for Linux aarch64
+        run: |
+          cmake -G Ninja -B build -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc
+          ninja -C build
+          aarch64-linux-gnu-strip build/espresso
+          mv build/espresso aarch64-linux-gnu-espresso
+          rm -rf build
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "*espresso"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
+          draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,27 +6,50 @@ on:
       - "*"
 
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-20.04
     steps:
       - run: |
           sudo apt update
           sudo apt install gcc-aarch64-linux-gnu ninja-build
       - uses: actions/checkout@v2
-      - name: Build for Linux X86_64
+      - name: Build for x86_64-linux-gnu
         run: |
           cmake -G Ninja -B build
           ninja -C build
           strip build/espresso
           mv build/espresso x86_64-linux-gnu-espresso
           rm -rf build
-      - name: Build for Linux aarch64
+      - name: Build for aarch64-linux-gnu
         run: |
           cmake -G Ninja -B build -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc
           ninja -C build
           aarch64-linux-gnu-strip build/espresso
           mv build/espresso aarch64-linux-gnu-espresso
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "*espresso"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
+          draft: true
+  build-macos:
+    runs-on: macos-10.15 # TODO update when 11 is out of private preview
+    steps:
+      - run: brew install ninja
+      - uses: actions/checkout@v2
+      - name: Build for x86_64-apple
+        run: |
+          cmake -G Ninja -B build
+          ninja -C build
+          strip build/espresso
+          mv build/espresso x86_64-apple-espresso
           rm -rf build
+      - name: Build for arm64-apple-macos11
+        run: |
+          cmake -G Ninja -B build -DCMAKE_C_COMPILER_TARGET=arm64-apple-macos11
+          ninja -C build
+          strip build/espresso
+          mv build/espresso arm64-apple-macos11-espresso
       - uses: ncipollo/release-action@v1
         with:
           artifacts: "*espresso"


### PR DESCRIPTION
This PR resolves https://github.com/chipsalliance/espresso/issues/5

It adds a GitHub Action to build those binaries and create a draft release. We can edit the release message manually, then promote that draft release to normal release.

Here is an example: https://github.com/sinofp/espresso/releases/tag/untagged-e713a3fd21a9b5e1429e

Note: I only have an x64 Linux machine, so I can't test other binaries.