### PR TITLE
Add equivalence test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,19 @@ jobs:
       - run: ./format.sh
       - name: Check changes
         run: git diff --quiet
+  equivalence-test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install fd
+        run: |
+          curl -OL https://github.com/sharkdp/fd/releases/download/v8.2.1/fd-musl_8.2.1_amd64.deb
+          sudo dpkg --install fd-musl_8.2.1_amd64.deb
+      - name: Download ESPRESSO-II
+        run: |
+          curl -L https://github.com/chipsalliance/espresso/releases/download/v2.4/x86_64-linux-gnu-espresso -o espresso2
+          sudo chmod +x espresso2
+      - name: Build current espresso
+        run: cmake -DBUILD_DOC=NO -B build && make -C build
+      - name: Use espresso2 -Dverify to check the equivalence
+        run: fd --exclude '*o64*' . examples/ --type f --exec bash -c 'printf "\n{}:\n" && ./espresso2 -Dverify {} <(build/espresso {})'


### PR DESCRIPTION
This test does the following things:
1. Download the original ESPRESSO-II binary as `espresso2`
2. Use the current implementation of espresso to minimize every example except o64.pla
3. Check the equivalence of the output and the original PLA using `espresso2 -Dverify` (and bash's process substitution)

I choose `fd` over `find` because `find` won't fail if one of `-exec xxx` fails. However, `fd` added this failing feature in 7.5.0 and ubuntu-20.04 only has 7.4.0, so I manually installed a newer version.