### PR TITLE
Fix crash on macOS by initializing the struct variable allocated on the stack

### DIFF
--- a/espresso/sparse.c
+++ b/espresso/sparse.c
@@ -12,7 +12,7 @@
 #include "espresso.h"
 
 pcover make_sparse(pcover F, pcover D, pcover R) {
-    cost_t cost = {}, best_cost = {};
+    cost_t cost = {.total = 0}, best_cost;
 
     cover_cost(F, &best_cost);
 

--- a/espresso/sparse.c
+++ b/espresso/sparse.c
@@ -12,7 +12,7 @@
 #include "espresso.h"
 
 pcover make_sparse(pcover F, pcover D, pcover R) {
-    cost_t cost, best_cost;
+    cost_t cost = {}, best_cost = {};
 
     cover_cost(F, &best_cost);
 


### PR DESCRIPTION
At least on macOS 14.2.1 (Apple clang version 15.0.0) `Release` build crashes with any input. As a result all tests fail as well.
The segfault happens in `make_sparse` function, at the first iteration of evaluating `ost.total == best_cost.total`.

The issue is probably related to the way `clang` optimizes uninitialized structs and subsequent operations on uninitialized fields.

Anyways the fix is very simple and I don't think would affect build or execution or any other platform.
